### PR TITLE
nix/ghc: support ghc 902 + 922

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -43,7 +43,7 @@ lookupFlagAssignment = lookup
 #endif
 
 llvmVersion :: Version
-llvmVersion = mkVersion [13,0]
+llvmVersion = mkVersion [14,0]
 
 -- Ordered by decreasing specificty so we will prefer llvm-config-9.0
 -- over llvm-config-9 over llvm-config.

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,20 @@
 {
   "nodes": {
-    "ds": {
+    "devshell": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1650900878,
-        "narHash": "sha256-qhNncMBSa9STnhiLfELEQpYC1L4GrYHNIzyCZ/pilsI=",
+        "lastModified": 1653308769,
+        "narHash": "sha256-9bylbRkrmaUiYYjcVLd0JyvqpKveOUw5q2mBf2+pR0c=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "d97df53b5ddaa1cfbea7cddbd207eb2634304733",
+        "rev": "a00abaeb902ff568f9542d4b6f335e3a4db5c548",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "master",
         "repo": "devshell",
         "type": "github"
       }
@@ -35,19 +34,33 @@
         "type": "github"
       }
     },
-    "fu": {
+    "flake-utils_2": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
-        "ref": "master",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1653590866,
+        "narHash": "sha256-E4yKIrt/S//WfW5D9IhQ1dVuaAy8RE7EiCMfnbrOC78=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3e81a637cdf9f6e9b39aeb4d6e6394d1ad158e16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
         "type": "github"
       }
     },
@@ -67,27 +80,24 @@
         "type": "github"
       }
     },
-    "np": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1651725581,
-        "narHash": "sha256-5KFbtrJIZ/KCdgo92qC8CYmOxcb2n+yOCeddCGkzviA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "2ab8e66328a9979ce69ed6d48a7e0fa7de5d42cb",
-        "type": "github"
+        "lastModified": 0,
+        "narHash": "sha256-yTa++bSwEexVaxX1OC/4JRM898MY7QNcRhDpF31HoyQ=",
+        "path": "/nix/store/5b40a3c56kvwrwxbrjbss0iz702vaial-source",
+        "type": "path"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "haskell-updates",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "root": {
       "inputs": {
-        "ds": "ds",
-        "fu": "fu",
-        "np": "np"
+        "devshell": "devshell",
+        "flake-utils": "flake-utils_2",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
                             substring 0 8 self.lastModifiedDate
                           }.${self.shortRev or "dirty"}";
                       }));
-                }) (hf: hp: { llvm-config = f.llvmPackages_13.llvm; }) hf hp);
+                }) (hf: hp: { llvm-config = f.llvmPackages_14.llvm; }) hf hp);
 
             # all haskellPackages
             allHaskellPackages = let

--- a/flake.nix
+++ b/flake.nix
@@ -1,59 +1,99 @@
 {
-  description =
-    "llvm-codegen: LLVM code generation using Haskell";
-  inputs = {
-    np.url = "github:nixos/nixpkgs?ref=haskell-updates";
-    fu.url = "github:numtide/flake-utils?ref=master";
-    ds.url = "github:numtide/devshell?ref=master";
-  };
-  outputs = { self, np, fu, ds }:
-    with np.lib;
-    with fu.lib;
+  description = "llvm-codegen: LLVM code generation using Haskell";
+
+  inputs.devshell.url = "github:numtide/devshell";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nix-filter.url = "github:numtide/nix-filter";
+
+  outputs = { self, flake-utils, nix-filter, devshell, nixpkgs }:
+    with nixpkgs.lib;
+    with flake-utils.lib;
     eachSystem [ "x86_64-linux" ] (system:
       let
-        ghcVersion = "902";
-        version = "${ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
-            self.shortRev or "dirty"
-          }";
+        rmDot = replaceStrings [ "." ] [ "" ];
+        supportedGHCs = [ "default" "902" "922" ];
         config = { };
-        overlay = final: _:
+        overlays.devshell = devshell.overlay;
+        overlays.default = f: p:
           let
-            haskellPackages =
-              final.haskell.packages."ghc${ghcVersion}".override {
-                overrides = hf: hp: {
-                  llvm-codegen =
-                    (hf.callCabal2nix "llvm-codegen" ./. {
-                      llvm-config = final.llvmPackages_13.llvm;
-                    });
-                };
-              };
-          in { inherit haskellPackages; };
+            ghcVersion = "ghc${rmDot p.haskellPackages.ghc.version}";
 
-        pkgs = import np {
+            mkHaskellPackages = hspkgs:
+              hspkgs.extend (hf: hp:
+                with f.haskell.lib;
+                composeExtensions (hf: hp: {
+                  llvm-codegen = disableLibraryProfiling
+                    ((hf.callCabal2nix "llvm-codegen" (with nix-filter.lib;
+                      filter {
+                        root = self;
+                        exclude = [ (matchExt "cabal") ];
+                      }) { }).overrideAttrs (old: {
+                        version = "${rmDot hp.ghc.version}-${old.version}-${
+                            substring 0 8 self.lastModifiedDate
+                          }.${self.shortRev or "dirty"}";
+                      }));
+                }) (hf: hp: { llvm-config = f.llvmPackages_13.llvm; }) hf hp);
+
+            # all haskellPackages
+            allHaskellPackages = let
+              cases = listToAttrs (map (n: {
+                name = "${n}";
+                value = mkHaskellPackages
+                  f.haskell.packages."${if n == "default" then
+                    "${ghcVersion}"
+                  else
+                    "ghc${n}"}";
+              }) supportedGHCs);
+            in cases;
+
+            # all packages
+            allPackages = listToAttrs (map (n: {
+              name = if n == "default" then n else "llvm-codegen-${n}";
+              value = allHaskellPackages."${n}".llvm-codegen;
+            }) supportedGHCs);
+
+            # make dev shell
+            mkDevShell = g:
+              p.devshell.mkShell {
+                name = "llvm-codegen-${
+                    if g == "default" then "${ghcVersion}" else g
+                  }-${substring 0 8 self.lastModifiedDate}.${
+                    self.shortRev or "dirty"
+                  }";
+                packages = with f;
+                  with f.allHaskellPackages."${g}"; [
+                    ghcid
+                    llvmPackages_13.llvm.dev
+                    (ghcWithPackages (hp:
+                      with hp; [
+                        llvm-codegen
+                        ghc
+                        cabal-install
+                        haskell-language-server
+                        hpack
+                        hsc2hs
+                      ]))
+                  ];
+              };
+
+            # all packages
+            allDevShells = listToAttrs (map (n: {
+              name = "${n}";
+              value = mkDevShell n;
+            }) supportedGHCs);
+          in {
+            haskellPackages = allHaskellPackages.default;
+            inherit allHaskellPackages allDevShells allPackages;
+          };
+
+        pkgs = import nixpkgs {
           inherit system config;
-          overlays = [ overlay ds.overlay ];
+          overlays = [ overlays.devshell overlays.default ];
         };
+
       in with pkgs.lib; rec {
-        inherit overlay;
-        packages = { inherit (pkgs.haskellPackages) llvm-codegen; };
-        defaultPackage = packages.llvm-codegen;
-        devShell = pkgs.devshell.mkShell {
-          name = "llvm-codegen";
-          imports = [];
-          packages = with pkgs;
-            with haskellPackages; [
-              pkgs.llvmPackages_13.llvm.dev
-              pkgs.ghcid
-              (ghcWithPackages (p:
-                with p; [
-                  hspec-discover
-                  ghc
-                  cabal-install
-                  hsc2hs
-                  hpack
-                  haskell-language-server
-                ]))
-            ];
-        };
+        inherit overlays;
+        packages = flattenTree (pkgs.recurseIntoAttrs pkgs.allPackages);
+        devShells = flattenTree (pkgs.recurseIntoAttrs pkgs.allDevShells);
       });
 }


### PR DESCRIPTION
Add support for multiple versions of GHC
```sh
>>= nix flake show --allow-import-from-derivation
git+file:///home/smunix/dev/llvm-codegen?ref=fix.ghc-multi&rev=4cc9d2dfd4878522d5361541f9ec05cde16c0ab7
├───devShells
│   └───x86_64-linux
│       ├───"902": development environment 'llvm-codegen-902-20220529.4cc9d2d'
│       ├───"922": development environment 'llvm-codegen-922-20220529.4cc9d2d'
│       └───default: development environment 'llvm-codegen-ghc902-20220529.4cc9d2d'
├───overlays
│   └───x86_64-linux: Nixpkgs overlay
└───packages
    └───x86_64-linux
        ├───default: package 'llvm-codegen-902-0.1.0.0-20220529.4cc9d2d'
        ├───llvm-codegen-902: package 'llvm-codegen-902-0.1.0.0-20220529.4cc9d2d'
        └───llvm-codegen-922: package 'llvm-codegen-922-0.1.0.0-20220529.4cc9d2d'
```
The `default` entries match whatever is the default for the `nixpkgs` in use.