### PR TITLE
Function attributes minimal support.

### DIFF
--- a/lib/LLVM/Codegen/FunctionAttributes.hs
+++ b/lib/LLVM/Codegen/FunctionAttributes.hs
@@ -1,0 +1,117 @@
+module LLVM.Codegen.FunctionAttributes (
+    FunctionAttribute (..)
+) where
+
+import LLVM.Pretty (Pretty(pretty))
+
+-- | Function attributes are set to communicate additional information about a function.
+-- | Function attributes are considered to be part of the function, not of the function type,
+-- | so functions with different function attributes can have the same function type.
+data FunctionAttribute
+    {- |
+    This function attribute indicates that the function never returns normally,
+    hence through a return instruction.
+
+    This produces undefined behavior at runtime if the function ever does dynamically return.
+    Annotated functions may still raise an exception, i.a., nounwind is not implied.
+    -}
+    = NoReturn
+    {- |
+    This function attribute indicates that the function never raises an exception.
+
+    If the function does raise an exception, its runtime behavior is undefined.
+    However, functions marked nounwind may still trap or generate asynchronous exceptions.
+    Exception handling schemes that are recognized by LLVM to handle asynchronous exceptions,
+    such as SEH, will still provide their implementation defined semantics.
+    -}
+    | NoUnwind
+    {- |
+    On a function, this attribute indicates that the function does not write through any pointer
+    arguments (including byval arguments) or otherwise modify any state
+    (e.g. memory, control registers, etc) visible outside the readonly function.
+
+    It may dereference pointer arguments and read state that may be set in the caller.
+    A readonly function always returns the same value (or unwinds an exception identically)
+    when called with the same set of arguments and global state. This means while it cannot unwind
+    exceptions by calling the C++ exception throwing methods (since they write to memory),
+    there may be non-C++ mechanisms that throw exceptions without writing to LLVM visible memory.
+
+    On an argument, this attribute indicates that the function does not write through this pointer
+    argument, even though it may write to the memory that the pointer points to.
+
+    If a readonly function writes memory visible outside the function, or has other side-effects,
+    the behavior is undefined. If a function writes to a readonly pointer argument,
+    the behavior is undefined.
+    -}
+    | ReadOnly
+    {- |
+    On a function, this attribute indicates that the function computes its result
+    (or decides to unwind an exception) based strictly on its arguments, without dereferencing
+    any pointer arguments or otherwise accessing any mutable state (e.g. memory, control registers, etc)
+    visible outside the readnone function.
+
+    It does not write through any pointer arguments (including byval arguments) and never changes any
+    state visible to callers. This means while it cannot unwind exceptions by calling the C++ exception
+    throwing methods (since they write to memory), there may be non-C++ mechanisms that throw exceptions
+    without writing to LLVM visible memory.
+
+    On an argument, this attribute indicates that the function does not dereference that pointer argument,
+    even though it may read or write the memory that the pointer points to if accessed through other pointers.
+
+    If a readnone function reads or writes memory visible outside the function, or has other side-effects,
+    the behavior is undefined. If a function reads from or writes to a readnone pointer argument,
+    the behavior is undefined.
+    -}
+    | ReadNone
+    -- | This attribute indicates that the inliner should attempt to inline this function into callers
+    -- | whenever possible, ignoring any active inlining size threshold for this caller.
+    | AlwaysInline
+    {- |
+    This attribute indicates that calls to the function cannot be duplicated. A call to a noduplicate
+    function may be moved within its parent function, but may not be duplicated within its parent function.
+
+    A function containing a noduplicate call may still be an inlining candidate, provided that the call
+    is not duplicated by inlining. That implies that the function has internal linkage and only has
+    one call site, so the original call is dead after inlining.
+    -}
+    | NoDuplicate
+    {- |
+    In some parallel execution models, there exist operations that cannot be made control-dependent
+    on any additional values. We call such operations convergent, and mark them with this attribute.
+
+    The convergent attribute may appear on functions or call/invoke instructions.
+    When it appears on a function, it indicates that calls to this function should not be made
+    control-dependent on additional values. For example, the intrinsic llvm.nvvm.barrier0 is convergent,
+    so calls to this intrinsic cannot be made control-dependent on additional values.
+
+    When it appears on a call/invoke, the convergent attribute indicates that we should treat the call
+    as though we’re calling a convergent function. This is particularly useful on indirect calls;
+    without this we may treat such calls as though the target is non-convergent.
+
+    The optimizer may remove the convergent attribute on functions when it can prove that the function
+    does not execute any convergent operations. Similarly, the optimizer may remove convergent on
+    calls/invokes when it can prove that the call/invoke cannot call a convergent function.
+    -}
+    | Convergent
+    {- |
+    This attribute indicates that the function may only access memory that is not accessible by the module
+    being compiled before return from the function. This is a weaker form of readnone.
+    If the function reads or writes other memory, the behavior is undefined.
+
+    -- For clarity, note that such functions are allowed to return new memory which is noalias with
+    respect to memory already accessible from the module. That is, a function can be both
+    inaccessiblememonly and have a noalias return which introduces a new, potentially initialized, allocation.
+    -}
+    | InaccessibleMemory
+    deriving stock (Eq, Ord, Show)
+
+instance Pretty FunctionAttribute where
+    pretty = \case
+      NoReturn -> "noreturn"
+      NoUnwind -> "nounwind"
+      ReadOnly -> "readonly"
+      ReadNone -> "readnone"
+      AlwaysInline -> "alwaysinline"
+      NoDuplicate -> "noduplicate"
+      Convergent -> "convergent"
+      InaccessibleMemory -> "inaccessiblememonly"

--- a/llvm-codegen.cabal
+++ b/llvm-codegen.cabal
@@ -37,6 +37,7 @@ library
       LLVM.Codegen.NameSupply
       LLVM.Codegen.Operand
       LLVM.Codegen.Type
+      LLVM.Codegen.FunctionAttributes
       LLVM.Pretty
   other-modules:
       Paths_llvm_codegen

--- a/tests/Test/LLVM/Codegen/IRBuilderSpec.hs
+++ b/tests/Test/LLVM/Codegen/IRBuilderSpec.hs
@@ -67,7 +67,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports functions" $ do
     let ir = do
-          function "do_add" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> do
+          function "do_add" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> do
             c <- add a b
             ret c
     checkIR ir [text|
@@ -80,10 +80,10 @@ spec = describe "constructing LLVM IR" $ do
 
   it "renders functions in order they are defined" $ do
     let ir = do
-          _ <- function "do_add" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> do
+          _ <- function "do_add" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> do
             c <- add a b
             ret c
-          function "do_add2" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> do
+          function "do_add2" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> do
             c <- add a b
             ret c
     checkIR ir [text|
@@ -104,7 +104,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports defining basic blocks" $ do
     let ir = do
-          function "do_add" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> do
+          function "do_add" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> do
             _ <- block
             c <- add a b
             ret c
@@ -120,7 +120,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports giving a basic block a user-defined name" $ do
     let ir = do
-          function "do_add" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> do
+          function "do_add" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> do
             c <- add a b
             ret c
     checkIR ir [text|
@@ -133,7 +133,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports giving function parameters a user-defined name" $ do
     let ir = do
-          function "do_add" [(i32, "arg0"), (i32, "arg1")] i32 $ \[a, b] -> do
+          function "do_add" [(i32, "arg0"), (i32, "arg1")] i32 [] $ \[a, b] -> do
             c <- add a b
             ret c
     checkIR ir [text|
@@ -146,7 +146,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports automatic naming of function parameters" $ do
     let ir = do
-          function "do_add" [(i32, NoParameterName), (i32, NoParameterName)] i32 $ \[a, b] -> do
+          function "do_add" [(i32, NoParameterName), (i32, NoParameterName)] i32 [] $ \[a, b] -> do
             c <- add a b
             ret c
     checkIR ir [text|
@@ -159,7 +159,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "automatically terminates previous basic block when starting new block" $ do
     let ir = do
-          function "do_add" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> mdo
+          function "do_add" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> mdo
             c <- add a b
             -- NOTE: invalid IR
             _ <- block `named` "next"
@@ -176,7 +176,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports giving instruction operands a user-defined name" $ do
     let ir = do
-          function "do_add" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> mdo
+          function "do_add" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> mdo
             c <- add a b `named` "c"
             d' <- flip named "d" $ do
               d <- add b c
@@ -194,7 +194,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "avoids name collissions by appending a unique suffix" $ do
     let ir = do
-          function "do_add" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> mdo
+          function "do_add" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> mdo
             c <- flip named "c" $ do
               c0 <- add a b
               add c0 c0
@@ -210,7 +210,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'add' instruction" $ do
     let ir = do
-          function "do_add" [(i8, "a"), (i8, "b")] i8 $ \[a, b] -> do
+          function "do_add" [(i8, "a"), (i8, "b")] i8 [] $ \[a, b] -> do
             c <- add a b
             ret c
     checkIR ir [text|
@@ -223,7 +223,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'mul' instruction" $ do
     let ir = do
-          function "func" [(i8, "a"), (i8, "b")] i8 $ \[a, b] -> do
+          function "func" [(i8, "a"), (i8, "b")] i8 [] $ \[a, b] -> do
             c <- mul a b
             ret c
     checkIR ir [text|
@@ -236,7 +236,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'sub' instruction" $ do
     let ir = do
-          function "func" [(i8, "a"), (i8, "b")] i8 $ \[a, b] -> do
+          function "func" [(i8, "a"), (i8, "b")] i8 [] $ \[a, b] -> do
             c <- sub a b
             ret c
     checkIR ir [text|
@@ -249,7 +249,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'udiv' instruction" $ do
     let ir = do
-          function "func" [(i8, "a"), (i8, "b")] i8 $ \[a, b] -> do
+          function "func" [(i8, "a"), (i8, "b")] i8 [] $ \[a, b] -> do
             c <- udiv a b
             ret c
     checkIR ir [text|
@@ -262,7 +262,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'and' instruction" $ do
     let ir = do
-          function "func" [(i1, "a"), (i1, "b")] i1 $ \[a, b] -> do
+          function "func" [(i1, "a"), (i1, "b")] i1 [] $ \[a, b] -> do
             c <- and a b
             ret c
     checkIR ir [text|
@@ -275,7 +275,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'trunc' instruction" $ do
     let ir = do
-          function "func" [(i64, "a")] i32 $ \[a] -> do
+          function "func" [(i64, "a")] i32 [] $ \[a] -> do
             b <- trunc a i32
             ret b
     checkIR ir [text|
@@ -288,7 +288,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'zext' instruction" $ do
     let ir = do
-          function "func" [(i32, "a")] i64 $ \[a] -> do
+          function "func" [(i32, "a")] i64 [] $ \[a] -> do
             b <- zext a i64
             ret b
     checkIR ir [text|
@@ -301,7 +301,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'ptrtoint' instruction" $ do
     let ir = do
-          function "func" [(ptr i32, "ptr_a")] i64 $ \[a] -> do
+          function "func" [(ptr i32, "ptr_a")] i64 [] $ \[a] -> do
             b <- ptrtoint a i64
             ret b
     checkIR ir [text|
@@ -314,7 +314,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'bitcast' instruction" $ do
     let ir = do
-          function "func" [(ptr i32, "ptr_a")] (ptr i64) $ \[a] -> do
+          function "func" [(ptr i32, "ptr_a")] (ptr i64) [] $ \[a] -> do
             b <- a `bitcast` ptr i64
             ret b
     checkIR ir [text|
@@ -340,7 +340,7 @@ spec = describe "constructing LLVM IR" $ do
           ]
     for_ scenarios $ \(cmp, cmpText) -> do
       let ir = do
-            function "func" [(i32, "a"), (i32, "b")] i1 $ \[a, b] -> do
+            function "func" [(i32, "a"), (i32, "b")] i1 [] $ \[a, b] -> do
               c <- icmp cmp a b
               ret c
       checkIR ir [text|
@@ -353,7 +353,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'alloca' instruction" $ do
     let ir = do
-          function "func" [(i32, "a")] i32 $ \[a] -> do
+          function "func" [(i32, "a")] i32 [] $ \[a] -> do
             _ <- alloca i64 Nothing 0
             _ <- alloca i1 (Just $ int32 8) 0
             _ <- alloca i1 Nothing 8
@@ -370,7 +370,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'gep' instruction on pointers" $ do
     let ir = do
-          function "func" [(ptr i64, "a"), (ptr (ptr (ptr i64)), "b")] (ptr i64) $ \[a, b] -> do
+          function "func" [(ptr i64, "a"), (ptr (ptr (ptr i64)), "b")] (ptr i64) [] $ \[a, b] -> do
             c <- gep a [int32 1]
             _ <- gep b [int32 1, int32 2, int32 3]
             ret c
@@ -388,7 +388,7 @@ spec = describe "constructing LLVM IR" $ do
           struct1 <- typedef "my_struct" Off [i32, i64]
           struct2 <- typedef "my_struct2" Off [struct1, i1]
 
-          function "func" [(ptr struct2, "a")] (ptr i64) $ \[a] -> do
+          function "func" [(ptr struct2, "a")] (ptr i64) [] $ \[a] -> do
             c <- gep a [int32 0, int32 0, int32 1]
             _ <- gep a [int32 0, int32 1]
             ret c
@@ -409,7 +409,7 @@ spec = describe "constructing LLVM IR" $ do
     let ir = do
           let array = ArrayType 10 i32
 
-          function "func" [(ptr array, "a")] (ptr i32) $ \[a] -> do
+          function "func" [(ptr array, "a")] (ptr i32) [] $ \[a] -> do
             c <- gep a [int32 0, int32 5]
             ret c
     checkIR ir [text|
@@ -422,7 +422,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'load' instruction" $ do
     let ir = do
-          function "func" [(ptr i64, "a")] i64 $ \[a] -> do
+          function "func" [(ptr i64, "a")] i64 [] $ \[a] -> do
             b <- load a 0
             _ <- load a 8
             ret b
@@ -437,7 +437,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'store' instruction" $ do
     let ir = do
-          function "func" [(ptr i64, "a")] void $ \[a] -> do
+          function "func" [(ptr i64, "a")] void [] $ \[a] -> do
             store a 0 (int64 10)
             store a 8 (int64 10)
             retVoid
@@ -452,7 +452,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'phi' instruction" $ do
     let ir = do
-          function "func" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> mdo
+          function "func" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> mdo
             c <- icmp EQ a b
             condBr c block1 block2
 
@@ -482,7 +482,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'call' instruction" $ do
     let ir = mdo
-          func <- function "func" [(i32, "a")] (i32) $ \[a] -> do
+          func <- function "func" [(i32, "a")] i32 [] $ \[a] -> do
             ret =<< call func [a]
 
           pure ()
@@ -496,7 +496,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'ret' instruction" $ do
     let ir = do
-          function "func" [(i1, "a")] i1 $ \[a] -> do
+          function "func" [(i1, "a")] i1 [] $ \[a] -> do
             ret a
     checkIR ir [text|
       define external ccc i1 @func(i1 %a_0) {
@@ -507,7 +507,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'retVoid' instruction" $ do
     let ir = do
-          function "func" [] void $ \[] -> do
+          function "func" [] void [] $ \[] -> do
             retVoid
     checkIR ir [text|
       define external ccc void @func() {
@@ -518,7 +518,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "only uses first terminator instruction" $ do
     let ir = do
-          function "func" [] i1 $ \[] -> do
+          function "func" [] i1 [] $ \[] -> do
             ret (bit 0)
             ret (bit 1)
     checkIR ir [text|
@@ -530,7 +530,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "doesn't emit a block if it has no instructions or terminator" $ do
     let ir = do
-          function "func" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> mdo
+          function "func" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> mdo
             isZero <- eq a (int32 0)
             if' isZero $ do
               _ <- add a b
@@ -556,7 +556,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'br' instruction" $ do
     let ir = do
-          function "func" [(i1, "a")] i1 $ \[a] -> mdo
+          function "func" [(i1, "a")] i1 [] $ \[a] -> mdo
             br block2
 
             block1 <- block
@@ -577,7 +577,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'condBr' instruction" $ do
     let ir = do
-          function "func" [(i1, "a")] i1 $ \[a] -> mdo
+          function "func" [(i1, "a")] i1 [] $ \[a] -> mdo
             condBr a block1 block2
 
             block1 <- block
@@ -603,7 +603,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'switch' instruction" $ do
     let ir = do
-          function "func" [(i1, "a")] i1 $ \[a] -> mdo
+          function "func" [(i1, "a")] i1 [] $ \[a] -> mdo
             switch a defaultBlock [(bit 1, block1), (bit 0, block2)]
             block1 <- block
             ret a
@@ -627,7 +627,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'select' instruction" $ do
     let ir = do
-          function "not" [(i1, "a")] i1 $ \[a] -> do
+          function "not" [(i1, "a")] i1 [] $ \[a] -> do
             b <- select a (bit 0) (bit 1)
             ret b
     checkIR ir [text|
@@ -640,7 +640,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'bit' for creating i1 values" $ do
     let ir = do
-          function "func" [] i1 $ \[] -> do
+          function "func" [] i1 [] $ \[] -> do
             ret (bit 1)
     checkIR ir [text|
       define external ccc i1 @func() {
@@ -649,7 +649,7 @@ spec = describe "constructing LLVM IR" $ do
       }
       |]
     let ir2 = do
-          function "func" [] i1 $ \[] -> do
+          function "func" [] i1 [] $ \[] -> do
             ret (bit 0)
     checkIR ir2 [text|
       define external ccc i1 @func() {
@@ -660,7 +660,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'int8' for creating i8 values" $ do
     let ir = do
-          function "func" [] i8 $ \[] -> do
+          function "func" [] i8 [] $ \[] -> do
             ret (int8 15)
     checkIR ir [text|
       define external ccc i8 @func() {
@@ -671,7 +671,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'int16' for creating i16 values" $ do
     let ir = do
-          function "func" [] i16 $ \[] -> do
+          function "func" [] i16 [] $ \[] -> do
             ret (int16 30)
     checkIR ir [text|
       define external ccc i16 @func() {
@@ -682,7 +682,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'int32' for creating i32 values" $ do
     let ir = do
-          function "func" [] i32 $ \[] -> do
+          function "func" [] i32 [] $ \[] -> do
             ret (int32 60)
     checkIR ir [text|
       define external ccc i32 @func() {
@@ -693,7 +693,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'int64' for creating i64 values" $ do
     let ir = do
-          function "func" [] i64 $ \[] -> do
+          function "func" [] i64 [] $ \[] -> do
             ret (int64 120)
     checkIR ir [text|
       define external ccc i64 @func() {
@@ -704,7 +704,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'intN' for creating iN values" $ do
     let ir = do
-          function "func" [] (IntType 42) $ \[] -> do
+          function "func" [] (IntType 42) [] $ \[] -> do
             ret (intN 42 1000)
     checkIR ir [text|
       define external ccc i42 @func() {
@@ -715,7 +715,7 @@ spec = describe "constructing LLVM IR" $ do
 
   it "supports 'nullPtr' for creating null values" $ do
     let ir = do
-          function "func" [] (ptr i8) $ \[] -> do
+          function "func" [] (ptr i8) [] $ \[] -> do
             ret $ nullPtr i8
     checkIR ir [text|
       define external ccc i8* @func() {

--- a/tests/Test/LLVM/Codegen/IRCombinatorsSpec.hs
+++ b/tests/Test/LLVM/Codegen/IRCombinatorsSpec.hs
@@ -25,7 +25,7 @@ spec = describe "IR builder combinators" $ parallel $ do
                     ]
     for_ scenarios $ \(f, op) -> do
       let ir = do
-            function "func" [(i32, "a"), (i32, "b")] i1 $ \[a, b] -> do
+            function "func" [(i32, "a"), (i32, "b")] i1 [] $ \[a, b] -> do
               c <- f a b
               ret c
       checkIR ir [text|
@@ -38,7 +38,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports 'one-sided if' combinator" $ do
     let ir = do
-          function "func" [(i32, "a"), (i32, "b")] i32 $ \[a, b] -> mdo
+          function "func" [(i32, "a"), (i32, "b")] i32 [] $ \[a, b] -> mdo
             isZero <- eq a (int32 0)
             if' isZero $ do
               _ <- add a b
@@ -60,7 +60,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports 'loop' combinator" $ do
     let ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             i <- allocate i32 (int32 0)
 
             loop $ do
@@ -92,7 +92,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports 'loopWhile combinator" $ do
     let ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             i <- allocate i32 (int32 10)
             let notZero = do
                   iVal <- load i 0
@@ -125,7 +125,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports 'loopFor' combinator" $ do
     let ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             x <- allocate i32 (int32 10)
 
             loopFor (int32 0) (`ult` int32 10) (add (int32 1)) $ \i -> do
@@ -157,7 +157,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports 'pointer subtraction' combinator" $ do
     let ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             ptr1 <- gep array [int32 0]
             ptr2 <- gep array [int32 3]
@@ -179,7 +179,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports logical not" $ do
     let ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             _ <- not' $ bit 0
             ret $ int32 42
     checkIR ir [text|
@@ -192,7 +192,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports computing the minimum of 2 values" $ do
     let ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             _result1 <- minimum' Signed (int32 100) (int32 42)
             _result2 <- minimum' Unsigned (int32 100) (int32 42)
             ret $ int32 42
@@ -209,7 +209,7 @@ spec = describe "IR builder combinators" $ parallel $ do
 
   it "supports allocating and initializing a variable on the stack" $ do
     let ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             _i <- allocate i32 (int32 0)
             ret $ int32 42
     checkIR ir [text|
@@ -228,7 +228,7 @@ spec = describe "IR builder combinators" $ parallel $ do
   it "supports computing the address based on a Path" $ do
     let path = Path [int32 5]
         ir = do
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             _address <- addr path array
             ret $ int32 42
@@ -244,7 +244,7 @@ spec = describe "IR builder combinators" $ parallel $ do
   it "supports dereferencing an address based on a Path" $ do
     let path = Path [int32 5]
         ir = mdo
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             _value <- deref path array
             ret $ int32 42
@@ -261,7 +261,7 @@ spec = describe "IR builder combinators" $ parallel $ do
   it "supports storing a value at an address based on a Path" $ do
     let path = Path [int32 5]
         ir = mdo
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             assign path array (int32 1000)
             ret $ int32 42
@@ -278,7 +278,7 @@ spec = describe "IR builder combinators" $ parallel $ do
   it "supports updating a value at an address based on a Path" $ do
     let path = Path [int32 5]
         ir = mdo
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             assign path array (int32 1000)
             update path array (add (int32 10))
@@ -300,7 +300,7 @@ spec = describe "IR builder combinators" $ parallel $ do
   it "supports incrementing a value at an address based on a Path" $ do
     let path = Path [int32 5]
         ir = mdo
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             assign path array (int32 1000)
             increment int32 path array
@@ -322,7 +322,7 @@ spec = describe "IR builder combinators" $ parallel $ do
   it "supports copying (part of) a type based on a Path" $ do
     let path = Path [int32 5]
         ir = mdo
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             assign path array (int32 1000)
             array2 <- alloca i32 (Just $ int32 5) 0
@@ -346,7 +346,7 @@ spec = describe "IR builder combinators" $ parallel $ do
   it "supports swapping (part of) a type based on a Path" $ do
     let path = Path [int32 5]
         ir = mdo
-          function "func" [] i32 $ \_ -> mdo
+          function "func" [] i32 [] $ \_ -> mdo
             array <- alloca i32 (Just $ int32 5) 0
             assign path array (int32 1000)
             array2 <- alloca i32 (Just $ int32 5) 0


### PR DESCRIPTION
Master issue: #3
LLVM documentation: [link](https://llvm.org/docs/LangRef.html#function-attributes).
Accelerate usage module: [link](https://github.com/AccelerateHS/accelerate-llvm/blob/master/accelerate-llvm/src/LLVM/AST/Type/Function.hs#L69).

Questions:
1. I broke backward compatibility when added extra argument in  `function`. Is it critical?
2. List of attributes can contains conflicting ones (`alwaysinline` and `noinline` for example). Should I implement some rule-based checker?

Plan:

- [x] Add attributes.
- [x] Repair broken tests.
- [ ] Add new tests.

Attributes:
- [x] noreturn
- [x] nounwind
- [x] readonly
- [x] readnone
- [x] alwaysinline
- [x] noduplicate
- [x] convergent
- [x] inaccessiblememory