### PR TITLE
build llvm-codegen for both macosx and linux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,6 +51,22 @@
         "type": "github"
       }
     },
+    "nf": {
+      "locked": {
+        "lastModified": 1661201956,
+        "narHash": "sha256-RizGJH/buaw9A2+fiBf9WnXYw4LZABB5kMAZIEE5/T8=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3b821578685d661a10b563cba30b1861eec05748",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1643381941,
@@ -87,6 +103,7 @@
       "inputs": {
         "ds": "ds",
         "fu": "fu",
+        "nf": "nf",
         "np": "np"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,18 @@
 {
-  description =
-    "llvm-codegen: LLVM code generation using Haskell";
+  description = "llvm-codegen: LLVM code generation using Haskell";
   inputs = {
     np.url = "github:nixos/nixpkgs?ref=haskell-updates";
     fu.url = "github:numtide/flake-utils?ref=master";
     ds.url = "github:numtide/devshell?ref=master";
+    nf.url = "github:numtide/nix-filter?ref=master";
   };
-  outputs = { self, np, fu, ds }:
+  outputs = { self, np, fu, ds, nf, ... }@inputs:
     with np.lib;
     with fu.lib;
     eachSystem [ "x86_64-linux" ] (system:
       let
         ghcVersion = "902";
+        llvmVersion = 13;
         version = "${ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
             self.shortRev or "dirty"
           }";
@@ -20,17 +21,31 @@
           let
             haskellPackages =
               final.haskell.packages."ghc${ghcVersion}".override {
-                overrides = hf: hp: {
-                  llvm-codegen =
-                    (hf.callCabal2nix "llvm-codegen" ./. {
-                      llvm-config = final.llvmPackages_14.llvm;
-                    });
-                };
+                overrides = with final.haskell.lib;
+                  hf: hp:
+                  let llvm = final."llvmPackages_${toString llvmVersion}".llvm;
+                  in {
+                    llvm-codegen = appendConfigureFlags
+                      ((hf.callCabal2nix "llvm-codegen" (with nf.lib;
+                        filter {
+                          root = self;
+                          exclude = [ ("Setup.hs") ];
+                        }) { llvm-config = llvm; }).overrideAttrs (old: {
+                               version = "${old.version}-${version}";
+                             })) [
+                          "--ghc-option=-optl=-L/${llvm}/lib"
+                          "--ghc-option=-optl=-I/${llvm}/include"
+                          "--ghc-option=-optl=-lLLVM-${toString llvmVersion}"
+                        ];
+                  };
               };
           in { inherit haskellPackages; };
 
         pkgs = import np {
-          inherit system config;
+          inherit config;
+          system = if system == "aarch64-darwin"
+                   then "x86_64-darwin"
+                   else system;
           overlays = [ overlay ds.overlay ];
         };
       in with pkgs.lib; rec {
@@ -39,7 +54,7 @@
         defaultPackage = packages.llvm-codegen;
         devShell = pkgs.devshell.mkShell {
           name = "llvm-codegen";
-          imports = [];
+          imports = [ ];
           packages = with pkgs;
             with haskellPackages; [
               pkgs.llvmPackages_14.llvm.dev

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     eachSystem [ "x86_64-linux" ] (system:
       let
         ghcVersion = "902";
-        llvmVersion = 13;
+        llvmVersion = 14;
         version = "${ghcVersion}.${substring 0 8 self.lastModifiedDate}.${
             self.shortRev or "dirty"
           }";


### PR DESCRIPTION
This fix removes Setup.hs from the build process and only relies on `nix` dependencies to complete the build. Tested on both macosx and linux (nixos), it builds successfully.
fixes: https://github.com/luc-tielen/eclair-lang/issues/14 