### PR TITLE
Support for GHC-9.4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ghc-version: ['9.2.7']
+        ghc-version: ['9.2.7', '9.4.4']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # llvm-codegen
+[![build](https://github.com/luc-tielen/llvm-codegen/actions/workflows/ci.yml/badge.svg)](https://github.com/luc-tielen/llvm-codegen/actions/workflows/ci.yml)
 
 A Haskell library for generating LLVM code. Inspired by the `llvm-hs`,
 `llvm-hs-pure`, `llvm-hs-combinators` and the `llvm-hs-pretty` libraries.

--- a/lib/LLVM/Codegen/IRBuilder/Monad.hs
+++ b/lib/LLVM/Codegen/IRBuilder/Monad.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies, RankNTypes, MultiParamTypeClasses, UndecidableInstances, BangPatterns #-}
+{-# LANGUAGE TypeFamilies, RankNTypes, MultiParamTypeClasses, UndecidableInstances, BangPatterns, TypeOperators #-}
 
 module LLVM.Codegen.IRBuilder.Monad
   ( IRBuilderT

--- a/lib/LLVM/Codegen/ModuleBuilder.hs
+++ b/lib/LLVM/Codegen/ModuleBuilder.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeFamilies, MultiParamTypeClasses, UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies, MultiParamTypeClasses, UndecidableInstances, TypeOperators #-}
 
 module LLVM.Codegen.ModuleBuilder
   ( ModuleBuilderT

--- a/llvm-codegen.cabal
+++ b/llvm-codegen.cabal
@@ -1,6 +1,6 @@
-cabal-version: 2.0
+cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -39,8 +39,6 @@ library
       LLVM.Pretty
   other-modules:
       Paths_llvm_codegen
-  autogen-modules:
-      Paths_llvm_codegen
   hs-source-dirs:
       lib
   default-extensions:
@@ -61,8 +59,6 @@ library
       LinearTypes
       MagicHash
   ghc-options: -Wall -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -optl=-lLLVM-14
-  build-tools:
-      llvm-config
   build-depends:
       base >=4.7 && <5
     , bytestring ==0.11.*
@@ -82,8 +78,6 @@ test-suite llvm-codegen-test
       Test.LLVM.C.APISpec
       Test.LLVM.Codegen.IRBuilderSpec
       Test.LLVM.Codegen.IRCombinatorsSpec
-      Paths_llvm_codegen
-  autogen-modules:
       Paths_llvm_codegen
   hs-source-dirs:
       tests
@@ -105,8 +99,6 @@ test-suite llvm-codegen-test
       LinearTypes
       MagicHash
   ghc-options: -Wall -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -optl=-lLLVM-14
-  build-tools:
-      llvm-config
   build-depends:
       base >=4.7 && <5
     , bytestring ==0.11.*

--- a/llvm-codegen.cabal
+++ b/llvm-codegen.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.24
+cabal-version: 2.0
 
 -- This file has been generated from package.yaml by hpack version 0.35.2.
 --
@@ -39,6 +39,8 @@ library
       LLVM.Pretty
   other-modules:
       Paths_llvm_codegen
+  autogen-modules:
+      Paths_llvm_codegen
   hs-source-dirs:
       lib
   default-extensions:
@@ -59,6 +61,8 @@ library
       LinearTypes
       MagicHash
   ghc-options: -Wall -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -optl=-lLLVM-14
+  build-tools:
+      llvm-config
   build-depends:
       base >=4.7 && <5
     , bytestring ==0.11.*
@@ -78,6 +82,8 @@ test-suite llvm-codegen-test
       Test.LLVM.C.APISpec
       Test.LLVM.Codegen.IRBuilderSpec
       Test.LLVM.Codegen.IRCombinatorsSpec
+      Paths_llvm_codegen
+  autogen-modules:
       Paths_llvm_codegen
   hs-source-dirs:
       tests
@@ -99,6 +105,8 @@ test-suite llvm-codegen-test
       LinearTypes
       MagicHash
   ghc-options: -Wall -fhide-source-paths -fno-show-valid-hole-fits -fno-sort-valid-hole-fits -optl=-lLLVM-14
+  build-tools:
+      llvm-config
   build-depends:
       base >=4.7 && <5
     , bytestring ==0.11.*

--- a/package.yaml
+++ b/package.yaml
@@ -47,8 +47,6 @@ ghc-options:
   - -fno-sort-valid-hole-fits
   - -optl=-lLLVM-14
 
-system-build-tools: llvm-config
-
 library:
   source-dirs: lib
 

--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,8 @@ ghc-options:
   - -fno-sort-valid-hole-fits
   - -optl=-lLLVM-14
 
+system-build-tools: llvm-config
+
 library:
   source-dirs: lib
 


### PR DESCRIPTION
+ Fixed compilation warnings with GHC-9.4.4
+ Added CI status badge in Readme
+ Removed `llvm-config` dependency from `package.yaml` since it is not providing much value