### PR TITLE
CI build fix for llvm version

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -44,7 +44,7 @@ lookupFlagAssignment = lookup
 
 supportedLLVMVersions :: [Version]
 supportedLLVMVersions =
-  [ mkVersion [17,0,0]
+  [ mkVersion [17,0,1]
   , mkVersion [16,0,0]
   , mkVersion [15,0,0]
   ]


### PR DESCRIPTION
- This is a fix for the following error seen in `eclair-lang` CI build:
```
374.1 Error: setup: The program 'llvm-config' version >=15.0.0 && <=17.0.0 is
374.1 required but the version found at /usr/bin/llvm-config-17 is version 17.0.1
374.1 
374.1 Error: cabal: Failed to build llvm-codegen-0.1.0.0 (which is required by
374.1 test:eclair-test from eclair-lang-0.2.0 and exe:eclair from
374.1 eclair-lang-0.2.0). See the build log above for details.
374.1 
374.1 make: *** [Makefile:2: build] Error 1
```