### PR TITLE
Update version bounds for `mmorph`

### DIFF
--- a/lib/LLVM/Codegen/IRBuilder/Monad.hs
+++ b/lib/LLVM/Codegen/IRBuilder/Monad.hs
@@ -26,10 +26,12 @@ import qualified Control.Monad.State.Strict as StrictState
 import qualified Control.Monad.State.Lazy as LazyState
 import qualified Control.Monad.RWS.Lazy as LazyRWS
 import qualified Control.Monad.RWS.Strict as StrictRWS
+import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.Writer
 import Control.Monad.Except
 import Control.Monad.Morph
+import Control.Monad.Fix
 import Data.Functor.Identity
 import qualified Data.Text as T
 import qualified Data.DList as DList
@@ -37,6 +39,7 @@ import Data.DList (DList)
 import qualified Data.Map as M
 import Data.Map (Map)
 import Data.Maybe
+import Data.Monoid
 import LLVM.Codegen.Operand
 import LLVM.Codegen.IR
 import LLVM.Codegen.Type

--- a/lib/LLVM/Codegen/ModuleBuilder.hs
+++ b/lib/LLVM/Codegen/ModuleBuilder.hs
@@ -32,6 +32,7 @@ import Control.Monad.Reader
 import Control.Monad.Writer
 import Control.Monad.Except
 import Control.Monad.Morph
+import Control.Monad.Fix
 import Data.DList (DList)
 import Data.Map (Map)
 import Data.String

--- a/llvm-codegen.cabal
+++ b/llvm-codegen.cabal
@@ -65,14 +65,14 @@ library
 
   build-tools:        llvm-config >=0
   build-depends:
-      base                 >=4.7   && <5
-    , bytestring           >=0.11  && <0.12
+      base                 >=4.7  && <5
+    , bytestring           >=0.11 && <0.12
     , containers           <1
-    , dlist                >=1     && <2
+    , dlist                >=1    && <2
     , ghc-prim             <1
-    , mmorph               ==1.1.5
-    , mtl                  >=2     && <3
-    , text                 >=2     && <3
+    , mmorph               >=1    && <2
+    , mtl                  >=2    && <3
+    , text                 >=2    && <3
     , text-builder-linear  <1
 
   default-language:   Haskell2010

--- a/llvm-codegen.cabal
+++ b/llvm-codegen.cabal
@@ -120,7 +120,7 @@ test-suite llvm-codegen-test
     , hspec                >=2.6.1 && <3.0.0
     , hspec-hedgehog       <1
     , llvm-codegen
-    , mmorph               ==1.1.5
+    , mmorph               >=1     && <2
     , mtl                  >=2     && <3
     , neat-interpolation   <1
     , text                 >=2     && <3


### PR DESCRIPTION
- Required for building eclair with GHC 9.6.2