### PR TITLE
Fix for ambiguous `show` error when compiling with ghc-9.2.7

### DIFF
--- a/lib/LLVM/Codegen/Name.hs
+++ b/lib/LLVM/Codegen/Name.hs
@@ -4,7 +4,7 @@ module LLVM.Codegen.Name
   , renderName
   ) where
 
-import Data.Text
+import Data.Text hiding (show)
 import Data.String
 import LLVM.Pretty
 


### PR DESCRIPTION
Fixes the following error when compiling with ghc-9.2.7
```
lib/LLVM/Codegen/Name.hs:23:26: error:
Error:     Ambiguous occurrence ‘show’
    It could refer to
       either ‘Prelude.show’,
              imported from ‘Prelude’ at lib/LLVM/Codegen/Name.hs:1:8-24
              (and originally defined in ‘GHC.Show’)
           or ‘Data.Text.show’,
              imported from ‘Data.Text’ at lib/LLVM/Codegen/Name.hs:7:1-16
   |
23 |   Generated x -> pack $! show x
   |                          ^^^^
Error: [Cabal-7125]
Failed to build llvm-codegen-0.1.0.0.
```